### PR TITLE
Fix broken images in README.md

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,45 @@
+name: Generate Snake
+
+on:
+  schedule:
+    - cron: "0 */12 * * *"
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Generate Snake
+        uses: Platane/snk@v2
+        with:
+          github_user_name: FlemingJohn
+          svg_out_path: dist/github-contribution-grid-snake.svg
+
+      - name: Push to output branch
+        uses: crazy-max/ghaction-github-pages@v2.5.0
+        with:
+          target_branch: output
+          build_dir: dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  metrics:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Generate Metrics
+        uses: lowlighter/metrics@latest
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          user: FlemingJohn
+          base: header, activity, community, repositories, metadata
+          plugin_lines: yes
+          plugin_habits: yes
+          plugin_habits.from: 200
+          plugin_habits.charts: yes
+          plugin_habits.trim: yes

--- a/README.md
+++ b/README.md
@@ -49,19 +49,19 @@
 
 ### 📈 GitHub Activity Graph
 
-![GitHub Activity Graph](https://github-readme-activity-graph.cyclic.app/graph?username=FlemingJohn&bg_color=000000&color=ffffff&line=00bcd4&point=ffffff&area=true&hide_border=true)
+![GitHub Activity Graph](https://github-readme-activity-graph.vercel.app/graph?username=FlemingJohn&bg_color=000000&color=ffffff&line=00bcd4&point=ffffff&area=true&hide_border=true)
 
 ---
 
 ### 📌 GitHub Metrics
 
-<img src="https://github.com/FlemingJohn/FlemingJohn/blob/main/github-metrics.svg" alt="Metrics" width="100%">
+<img src="https://raw.githubusercontent.com/FlemingJohn/FlemingJohn/main/github-metrics.svg" alt="Metrics" width="100%">
 
 ---
 
 ### 🐍 GitHub Contribution Snake
 
-![snake gif](https://github.com/FlemingJohn/FlemingJohn/blob/output/github-contribution-grid-snake.svg)
+![snake gif](https://raw.githubusercontent.com/FlemingJohn/FlemingJohn/output/dist/github-contribution-grid-snake.svg)
 
 ---
 


### PR DESCRIPTION
This commit fixes the broken GitHub Contribution Snake, GitHub Metrics, and GitHub Activity Graph images in the README.md file.

- Creates a new GitHub workflow to generate the GitHub Contribution Snake and GitHub Metrics images.
- Updates the README.md to use the correct URLs for the generated images.
- Replaces the broken URL for the GitHub Activity Graph with a working alternative.