### PR TITLE
Fix: Use secrets.GITHUB_TOKEN in snake workflow

### DIFF
--- a/.github/workflows/snake.yml
+++ b/.github/workflows/snake.yml
@@ -19,7 +19,7 @@ jobs:
           outputs: |
             ./github-contribution-grid-snake.svg
         env:
-          GITHUB_TOKEN: ${{ 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 }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Push to GitHub
         uses: EndBug/add-and-commit@v9


### PR DESCRIPTION
Replaced the hardcoded GITHUB_TOKEN with the standard secrets.GITHUB_TOKEN in the snake contribution graph workflow. This resolves the security vulnerability and fixes the likely cause of the graph generation failure due to an invalid or expired token.

## Summary by Sourcery

Use the built-in GITHUB_TOKEN in the snake workflow to replace the insecure hardcoded PAT and ensure valid authentication for contribution graph generation

Bug Fixes:
- Replace the hardcoded GITHUB_TOKEN value with secrets.GITHUB_TOKEN in the snake workflow

Enhancements:
- Improve security and reliability of the graph generation by leveraging the standard secrets.GITHUB_TOKEN